### PR TITLE
Fixed variable name

### DIFF
--- a/lib/eckey.js
+++ b/lib/eckey.js
@@ -6,7 +6,7 @@ module.exports = ECKey
 
 
 function ECKey (bytes, compressed) {
-  if (!(this instanceof ECKey)) return new ECKey(input);
+  if (!(this instanceof ECKey)) return new ECKey(bytes);
 
   this._compressed = compressed || !!ECKey.compressByDefault;
 


### PR DESCRIPTION
when using the ECKey constructor as a regular function without `new`
