### PR TITLE
Pass the `compressed` flag when used without `new`

### DIFF
--- a/lib/eckey.js
+++ b/lib/eckey.js
@@ -6,7 +6,7 @@ module.exports = ECKey
 
 
 function ECKey (bytes, compressed) {
-  if (!(this instanceof ECKey)) return new ECKey(bytes);
+  if (!(this instanceof ECKey)) return new ECKey(bytes, compressed);
 
   this._compressed = compressed || !!ECKey.compressByDefault;
 


### PR DESCRIPTION
Fixes #9.
